### PR TITLE
byebug is referenced in two different locations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,6 @@ group :development do
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
-  gem 'byebug'
   gem 'rspec-rails'
   gem 'awesome_print'
   gem 'bundler-audit'


### PR DESCRIPTION
The gem byebug is referenced in `development` group and `development, test` group.  Remove from `development` only group.