### PR TITLE
Remove dependent Destroy for post relationship

### DIFF
--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -10,6 +10,6 @@
 #
 
 class Tagging < ApplicationRecord
-  belongs_to :post, dependent: :destroy
+  belongs_to :post
   belongs_to :tag
 end


### PR DESCRIPTION
Posts weren't getting deleted unless you individually removed the taggings. Removing the dependency enables posts to be deleted while deleting the dependent taggings.